### PR TITLE
SCMOD-8829:  use 4.3.0-SCMOD-8829-SNAPSHOT build of worker document framework, till all workers are not moved to caf-dependency-management-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <copyrightNotice>Copyright ${copyrightYear} Micro Focus or one of its affiliates.</copyrightNotice>
 
         <!--BOM dependencies versions-->
-        <caf.worker-document-framework.bom.version>4.3.0-SNAPSHOT</caf.worker-document-framework.bom.version>
+        <caf.worker-document-framework.bom.version>4.3.0-SCMOD-8829-SNAPSHOT</caf.worker-document-framework.bom.version>
         <com.fasterxml.jackson.bom.version>2.10.3</com.fasterxml.jackson.bom.version>
         <io.dropwizard.bom.version>2.0.2</io.dropwizard.bom.version>
         <org.glassfish.jersey.bom.version>2.30.1</org.glassfish.jersey.bom.version>


### PR DESCRIPTION
 use 4.3.0-SCMOD-8829-SNAPSHOT build of worker document framework, till all workers are not moved to caf-dependency-management-bom