### PR TITLE
SCMOD-9580: Updated Marathon Client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <com.independentsoft.jmsg.version>2.0</com.independentsoft.jmsg.version>
         <com.jayway.jsonpath.version>2.4.0</com.jayway.jsonpath.version>
         <com.mchange.c3p0.version>0.9.5.5</com.mchange.c3p0.version>
-        <com.mesosphere.marathon-client.version>0.6.2</com.mesosphere.marathon-client.version>
+        <com.mesosphere.marathon-client.version>0.6.3</com.mesosphere.marathon-client.version>
         <com.neovisionaries.nv-i18n.version>1.27</com.neovisionaries.nv-i18n.version>
         <com.nitorcreations.junit-runners.version>1.2</com.nitorcreations.junit-runners.version>
         <com.rabbitmq.version>5.8.0</com.rabbitmq.version>


### PR DESCRIPTION
This change is to bring in version 9.7 of com.nimbusds:nimbus-jose-jwt which is a transitive dependency of the marathon client.