### PR TITLE
SCMOD-10461: Upgrading org.eclipse.persistence:eclipselink and org.eclipse.persistence:org.eclipse.persistence.extension version to 2.7.7 and org.eclipse.persistence:javax.persistence version to 2.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,9 +148,9 @@
         <org.apache.lucene.version>8.0.0</org.apache.lucene.version>
         <org.apache.velocity.version>1.7</org.apache.velocity.version>
         <org.codehaus.jettison.version>1.4.0</org.codehaus.jettison.version>
-        <org.eclipse.persistence.eclipselink.version>2.7.2</org.eclipse.persistence.eclipselink.version>
-        <org.eclipse.persistence.extension.version>2.7.2</org.eclipse.persistence.extension.version>
-        <org.eclipse.persistence.javax.persistence.version>2.1.1</org.eclipse.persistence.javax.persistence.version>
+        <org.eclipse.persistence.eclipselink.version>2.7.7</org.eclipse.persistence.eclipselink.version>
+        <org.eclipse.persistence.extension.version>2.7.7</org.eclipse.persistence.extension.version>
+        <org.eclipse.persistence.javax.persistence.version>2.2.1</org.eclipse.persistence.javax.persistence.version>
         <org.flywaydb.version>5.2.4</org.flywaydb.version><!--Latest 6.4.0 needs changes-->
         <org.glassfish.javax.el.version>3.0.1-b11</org.glassfish.javax.el.version>
         <org.hdrhistogram.version>2.1.11</org.hdrhistogram.version>


### PR DESCRIPTION
https://portal.digitalsafe.net/browse/SCMOD-10461